### PR TITLE
Added Gevent pywsgi support & ApacheBench results

### DIFF
--- a/fiole.py
+++ b/fiole.py
@@ -1233,6 +1233,13 @@ def run_gevent(host, port, handler):
     srv = pywsgi.WSGIServer((host, port), handler)
     srv.serve_forever()
 
+def run_bjoern(host, port, handler):
+    """Adapter to run the async Bjoern Wsgi server"""
+    # https://github.com/jonashaag/bjoern
+    import bjoern
+    bjoern.listen(handler, host, port)
+    bjoern.run()
+    
 def run_fiole(app=default_app, server=run_wsgiref, host=None, port=None):
     """Run the *Fiole* web server."""
     if not hasattr(app, 'secret_key'):

--- a/fiole.py
+++ b/fiole.py
@@ -1225,7 +1225,13 @@ def run_wsgiref(host, port, handler):
 
     srv = make_server(host, port, handler)
     srv.serve_forever()
-
+    
+def run_gevent(host, port, handler):
+    "Run the gevent async pywsgi wrapper; patch IO to non-blocking ops."
+	from gevent import monkey; monkey.patch_all()
+	from gevent import pywsgi
+	srv = pywsgi.WSGIServer((host, port), handler)
+	srv.serve_forever()
 
 def run_fiole(app=default_app, server=run_wsgiref, host=None, port=None):
     """Run the *Fiole* web server."""

--- a/fiole.py
+++ b/fiole.py
@@ -1227,11 +1227,11 @@ def run_wsgiref(host, port, handler):
     srv.serve_forever()
     
 def run_gevent(host, port, handler):
-    "Run the gevent async pywsgi wrapper; patch IO to non-blocking ops."
-	from gevent import monkey; monkey.patch_all()
-	from gevent import pywsgi
-	srv = pywsgi.WSGIServer((host, port), handler)
-	srv.serve_forever()
+    """Run the gevent async pywsgi wrapper; patch IO to non-blocking ops."""
+    from gevent import monkey; monkey.patch_all()
+    from gevent import pywsgi
+    srv = pywsgi.WSGIServer((host, port), handler)
+    srv.serve_forever()
 
 def run_fiole(app=default_app, server=run_wsgiref, host=None, port=None):
     """Run the *Fiole* web server."""


### PR DESCRIPTION
Hi, you did a nice job with fiole despite alpha status. 
Before I found your project, I though as well to merge a speed of wheezy with lean syntax / simplicity / features of itty, flask.... ;-)

I have tried some simple benchmarks with a demo " hello word" app. 
With "gevent server" patch, the results were rather impressive. 

ApacheBech results:
Concurrency Level:      100
Time taken for tests:   2.794 seconds
Complete requests:      10000
Failed requests:        0
Total transferred:      1470000 bytes
HTML transferred:       120000 bytes
Requests per second:    3578.54 #/sec (mean)
Time per request:       27.944 ms (mean)
Time per request:       0.279 sec. (mean, across all concurrent requests)
Transfer rate:          513.72 Kbytes/sec received

Setup: App server running at localhost callback, ApacheBenchmark running from the same computer (Notebook Lenovo u310 with Intel(R) Core(TM) i7-3517U CPU @ 1.90GHz, OS: Ubuntu 14.04 x64,  Python 2.7 x64)
